### PR TITLE
Improve Debug Logs

### DIFF
--- a/src/notebook/apexNotebookController.ts
+++ b/src/notebook/apexNotebookController.ts
@@ -141,11 +141,8 @@ export default class NotebookController {
         } 
         if(response.logs) {
             if(vscode.workspace.getConfiguration().get(CONSTANTS.SETTING_KEY_DISPLAY_DEBUG_ONLY)) {
-                const outputText = response.logs
-                    .split('\n')
-                    .map(line => line.includes('USER_DEBUG') ? line.split('|').slice(2).join('|') : null)
-                    .filter(Boolean)
-                    .join('\n');    
+                let reg = /(?<timestamp>^\d+:\d+:\d+.\d+) \((?<ns>\d+)\)\|(?<eventName>.+?)\|\[(?<lineNumber>.+?)\]\|(?<details>[\s\S]*?)\n*(?=^\d+:\d+:\d+.\d+)/gm;
+                const outputText = Array.from(response.logs.matchAll(reg)).map(e => e.groups).filter(e => e.eventName === 'USER_DEBUG').map(e => `[${e.lineNumber.padStart(3,'0')}]|${e.details}`).join('\n') 
     
                 pExecutionTask.appendOutput(new vscode.NotebookCellOutput([
                     vscode.NotebookCellOutputItem.text(outputText || 'No debugs found')


### PR DESCRIPTION
add regex to parse log rows. There are capturing groups for event name, line number, timestamp etc. We can use those to easily filter only specific events like USER_DEBUG and then display it in a better way. For example padding line numbers so that the debugs are better aligned.

Main thing this add is support for multiline debugs logs, for example when you JSON.serializePretty